### PR TITLE
Remove Old Ruby Versions from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
   - 2.3
+  - 2.4
 
 notifications:
   email: false


### PR DESCRIPTION
In this project's gemspec, the required Ruby version is >= 2.3 but
travis was building 1.9.3, 2.0, 2.1, and 2.2 which are unnecessary since
the required Ruby version is higher than all of those.

I also added 2.4 